### PR TITLE
API-2464 Refactored ApiClient and moved exception handling to API classes

### DIFF
--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -559,130 +559,13 @@ public class ApiClient implements AutoCloseable {
         }
     }
 
-    /**
-     * Invoke API by sending HTTP request with the given options.
-     *
-     * @param path         The sub-path of the HTTP URL
-     * @param method       The request method, one of "GET", "POST", "PUT", and "DELETE"
-     * @param queryParams  The query parameters
-     * @param body         The request body object - if it is not binary, otherwise null
-     * @param headerParams The header parameters
-     * @param formParams   The form parameters
-     * @param accept       The request's Accept header
-     * @param contentType  The request's Content-Type header
-     * @param authNames    The authentications to apply
-     * @return The response body in type of string
-     */
-    public <T> ApiResponse<T> invokeAPIVerbose(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeReference<T> returnType) throws ApiException, IOException {
-        return invokeAPIVerbose(new ApiRequestWrapper<>(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames), returnType);
+    public <T> ApiResponse<T> invoke(ApiRequest<?> request, TypeReference<T> returnType) throws ApiException, IOException {
+        return getAPIResponse(request, returnType);
     }
 
-    public <T> ApiResponse<T> invokeAPIVerbose(ApiRequest<?> request, TypeReference<T> returnType) throws ApiException, IOException {
-        try {
-            return getAPIResponse(request, returnType);
-        }
-        catch (ApiException exception) {
-            @SuppressWarnings("unchecked")
-            ApiResponse<T> response = (ApiResponse<T>)exception;
-            return response;
-        }
-        catch (Throwable exception) {
-            if (shouldThrowErrors) {
-                if (exception instanceof IOException) {
-                    throw (IOException) exception;
-                }
-                throw new IOException("Failed to complete HTTP request.", exception);
-            }
-            return new ApiExceptionResponse<>(exception);
-        }
-    }
-
-    public <T> Future<ApiResponse<T>> invokeAPIVerboseAsync(ApiRequest<?> request, TypeReference<T> returnType, AsyncApiCallback<ApiResponse<T>> callback) {
+    public <T> Future<ApiResponse<T>> invokeAsync(ApiRequest<?> request, TypeReference<T> returnType, AsyncApiCallback<ApiResponse<T>> callback) {
         SettableFuture<ApiResponse<T>> future = SettableFuture.create();
-        getAPIResponseAsync(request, returnType, new AsyncApiCallback<ApiResponse<T>>() {
-            @Override
-            public void onCompleted(ApiResponse<T> response) {
-                notifySuccess(future, callback, response);
-            }
-
-            @Override
-            public void onFailed(Throwable exception) {
-                if (exception instanceof ApiException) {
-                    @SuppressWarnings("unchecked")
-                    ApiResponse<T> response = (ApiResponse<T>)exception;
-                    notifySuccess(future, callback, response);
-                }
-                else if (shouldThrowErrors) {
-                    notifyFailure(future, callback, exception);
-                }
-                else {
-                    notifySuccess(future, callback, new ApiExceptionResponse<>(exception));
-
-                }
-            }
-        });
-        return future;
-    }
-
-    /**
-     * Invoke API by sending HTTP request with the given options.
-     *
-     * @param path         The sub-path of the HTTP URL
-     * @param method       The request method, one of "GET", "POST", "PUT", and "DELETE"
-     * @param queryParams  The query parameters
-     * @param body         The request body object - if it is not binary, otherwise null
-     * @param headerParams The header parameters
-     * @param formParams   The form parameters
-     * @param accept       The request's Accept header
-     * @param contentType  The request's Content-Type header
-     * @param authNames    The authentications to apply
-     * @return The response body in type of string
-     */
-    public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeReference<T> returnType) throws ApiException, IOException {
-        T response = null;
-        try {
-            response = invokeAPIVerbose(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames, returnType).getBody();
-            return response;
-        } catch (ApiException e) {
-            if (shouldThrowErrors)
-                throw e;
-            else
-                return response;
-        }
-    }
-
-    /**
-     * Invoke API by sending HTTP request with the given options.
-     *
-     * @param request The request object
-     * @return The response body in type of string
-     */
-    public <T> T invokeAPI(ApiRequest<?> request, TypeReference<T> returnType) throws ApiException, IOException {
-        T response = null;
-        try {
-            response = invokeAPIVerbose(request, returnType).getBody();
-            return response;
-        } catch (ApiException e) {
-            if (shouldThrowErrors)
-                throw e;
-            else
-                return response;
-        }
-    }
-
-    public <T> Future<T> invokeAPIAsync(ApiRequest<?> request, TypeReference<T> returnType, AsyncApiCallback<T> callback) {
-        SettableFuture<T> future = SettableFuture.create();
-        invokeAPIVerboseAsync(request, returnType, new AsyncApiCallback<ApiResponse<T>>() {
-            @Override
-            public void onCompleted(ApiResponse<T> response) {
-                notifySuccess(future, callback, response.getBody());
-            }
-
-            @Override
-            public void onFailed(Throwable exception) {
-                notifyFailure(future, callback, exception);
-            }
-        });
+        getAPIResponseAsync(request, returnType, callback);
         return future;
     }
 
@@ -1000,62 +883,6 @@ public class ApiClient implements AutoCloseable {
         @Override
         public String getCorrelationId() {
             return headers.get("ININ-Correlation-ID");
-        }
-
-        @Override
-        public void close() throws Exception { }
-    }
-
-    private static class ApiExceptionResponse<T> implements ApiResponse<T> {
-        private final Exception exception;
-
-        public ApiExceptionResponse(Throwable exception) {
-            this.exception = (exception instanceof Exception) ? (Exception)exception : new RuntimeException(exception);
-        }
-
-        @Override
-        public Exception getException() {
-            return exception;
-        }
-
-        @Override
-        public Integer getStatusCode() {
-            return 500;
-        }
-
-        @Override
-        public String getStatusReasonPhrase() {
-            return exception.getMessage();
-        }
-
-        @Override
-        public boolean hasRawBody() {
-            return false;
-        }
-
-        @Override
-        public String getRawBody() {
-            return "";
-        }
-
-        @Override
-        public T getBody() {
-            return null;
-        }
-
-        @Override
-        public Map<String, String> getHeaders() {
-            return Collections.emptyMap();
-        }
-
-        @Override
-        public String getHeader(String key) {
-            return "";
-        }
-
-        @Override
-        public String getCorrelationId() {
-            return "";
         }
 
         @Override

--- a/resources/sdk/purecloudjava/templates/api.mustache
+++ b/resources/sdk/purecloudjava/templates/api.mustache
@@ -46,7 +46,7 @@ public class {{classname}} {
    * @throws ApiException if fails to make API call
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException, ApiException {
-    {{#returnType}}return {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}.getBody(){{/returnType}};
+    {{#returnType}}return {{/returnType}} {{operationId}}(create{{requestClassname}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}));
   }
 
   /**
@@ -56,48 +56,15 @@ public class {{classname}} {
    * @return {{{returnType}}}{{/returnType}}
    * @throws ApiException if fails to make API call
    */
-  public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException, ApiException {
-    Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
-    {{#allParams}}{{#required}}
-    // verify the required parameter '{{paramName}}' is set
-    if ({{paramName}} == null) {
-      throw new IllegalArgumentException("Missing the required parameter '{{paramName}}' when calling {{operationId}}");
-    }
-    {{/required}}{{/allParams}}
-    // create path and map variables
-    String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+  public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException, ApiException {
+    return {{operationId}}(create{{requestClassname}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).withHttpInfo());
+  }
 
-    // query params
-    {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();
-    {{javaUtilPrefix}}Map<String, String> {{localVariablePrefix}}localVarHeaderParams = new {{javaUtilPrefix}}HashMap<String, String>();
-    {{javaUtilPrefix}}Map<String, Object> {{localVariablePrefix}}localVarFormParams = new {{javaUtilPrefix}}HashMap<String, Object>();
-
-    {{#queryParams}}
-    {{localVariablePrefix}}localVarQueryParams.addAll({{localVariablePrefix}}apiClient.parameterToPairs("{{#collectionFormat}}{{{collectionFormat}}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));
-    {{/queryParams}}
-
-    {{#headerParams}}if ({{paramName}} != null)
-      {{localVariablePrefix}}localVarHeaderParams.put("{{baseName}}", {{localVariablePrefix}}apiClient.parameterToString({{paramName}}));
-    {{/headerParams}}
-
-    {{#formParams}}if ({{paramName}} != null)
-      {{localVariablePrefix}}localVarFormParams.put("{{baseName}}", {{paramName}});
-    {{/formParams}}
-
-    final String[] {{localVariablePrefix}}localVarAccepts = {
-      {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}}
-    };
-    final String {{localVariablePrefix}}localVarAccept = {{localVariablePrefix}}apiClient.selectHeaderAccept({{localVariablePrefix}}localVarAccepts);
-
-    final String[] {{localVariablePrefix}}localVarContentTypes = {
-      {{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}}
-    };
-    final String {{localVariablePrefix}}localVarContentType = {{localVariablePrefix}}apiClient.selectHeaderContentType({{localVariablePrefix}}localVarContentTypes);
-
-    String[] {{localVariablePrefix}}localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };
-
-    return {{localVariablePrefix}}apiClient.invokeAPIVerbose({{localVariablePrefix}}localVarPath, "{{httpMethod}}", {{localVariablePrefix}}localVarQueryParams, {{localVariablePrefix}}localVarPostBody, {{localVariablePrefix}}localVarHeaderParams, {{localVariablePrefix}}localVarFormParams, {{localVariablePrefix}}localVarAccept, {{localVariablePrefix}}localVarContentType, {{localVariablePrefix}}localVarAuthNames, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
+  private {{requestClassname}} create{{requestClassname}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+    return {{requestClassname}}.builder(){{#allParams}}
+            .with{{paramTitle}}({{paramName}})
+    {{/allParams}}
+            .build();
   }
 
   /**
@@ -107,7 +74,14 @@ public class {{classname}} {
    * @throws ApiException if fails to make API call
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{requestClassname}} request) throws IOException, ApiException {
-    {{#returnType}}return {{/returnType}}{{localVariablePrefix}}apiClient.invokeAPI(request.withHttpInfo(), {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
+    try {
+      ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response = {{localVariablePrefix}}apiClient.invoke(request.withHttpInfo(), {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
+      {{#returnType}}return response.getBody();{{/returnType}}
+    }
+    catch (ApiException | IOException exception) {
+      if ({{localVariablePrefix}}apiClient.getShouldThrowErrors()) throw exception;
+      {{#returnType}}return null;{{/returnType}}
+    }
   }
 
   /**
@@ -117,7 +91,25 @@ public class {{classname}} {
    * @throws ApiException if fails to make API call
    */
   public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request) throws IOException, ApiException {
-    return {{localVariablePrefix}}apiClient.<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>invokeAPIVerbose(request, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
+    try {
+      return {{localVariablePrefix}}apiClient.invoke(request, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
+    }
+    catch (ApiException exception) {
+      @SuppressWarnings("unchecked")
+      ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response = (ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>)(ApiResponse<?>)exception;
+      return response;
+    }
+    catch (Throwable exception) {
+      if ({{localVariablePrefix}}apiClient.getShouldThrowErrors()) {
+        if (exception instanceof IOException) {
+          throw (IOException)exception;
+        }
+        throw new RuntimeException(exception);
+      }
+      @SuppressWarnings("unchecked")
+      ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response = (ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>)(ApiResponse<?>)(new ApiException(exception));
+      return response;
+    }
   }
 
   {{/operation}}

--- a/resources/sdk/purecloudjava/templates/apiException.mustache
+++ b/resources/sdk/purecloudjava/templates/apiException.mustache
@@ -5,7 +5,7 @@ import java.util.Map;
 
 {{>generatedAnnotation}}
 public class ApiException extends Exception implements ApiResponse<Object> {
-    private final int statusCode;
+    private final Integer statusCode;
     private final Map<String, String> headers;
     private final String body;
 
@@ -14,6 +14,13 @@ public class ApiException extends Exception implements ApiResponse<Object> {
         this.statusCode = statusCode;
         this.headers = Collections.unmodifiableMap(headers);
         this.body = body;
+    }
+
+    public ApiException(Throwable cause) {
+        super(cause);
+        this.statusCode = null;
+        this.headers = Collections.emptyMap();
+        this.body = null;
     }
 
     @Override

--- a/resources/sdk/purecloudjava/templates/api_async.mustache
+++ b/resources/sdk/purecloudjava/templates/api_async.mustache
@@ -1,6 +1,8 @@
 package {{package}};
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
 
 import {{invokerPackage}}.AsyncApiCallback;
 import {{invokerPackage}}.ApiException;
@@ -47,7 +49,30 @@ public class {{classname}}Async {
    * @throws ApiException if fails to make API call
    */
   public Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}Async({{requestClassname}} request, AsyncApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> callback) {
-    return {{localVariablePrefix}}apiClient.<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>invokeAPIAsync(request.withHttpInfo(), {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}}, callback);
+    try {
+      SettableFuture<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> future = SettableFuture.create();
+      boolean shouldThrowErrors = {{localVariablePrefix}}apiClient.getShouldThrowErrors();
+      {{localVariablePrefix}}apiClient.invokeAsync(request.withHttpInfo(), null, new AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>>() {
+        @Override
+        public void onCompleted(ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response) {
+          notifySuccess(future, callback, response.getBody());
+        }
+
+        @Override
+        public void onFailed(Throwable exception) {
+          if (shouldThrowErrors) {
+            notifyFailure(future, callback, exception);
+          }
+          else {
+            notifySuccess(future, callback, null);
+          }
+        }
+      });
+      return future;
+    }
+    catch (Throwable exception) {
+      return Futures.immediateFailedFuture(exception);
+    }
   }
 
   /**
@@ -56,10 +81,70 @@ public class {{classname}}Async {
    * @request The request object
    * @throws ApiException if fails to make API call
    */
-  public Future<{{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}}> {{operationId}}Async(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request, AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> callback) {
-    return {{localVariablePrefix}}apiClient.<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>invokeAPIVerboseAsync(request, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}}, callback);
+  public Future<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> {{operationId}}Async(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request, AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> callback) {
+    try {
+      SettableFuture<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> future = SettableFuture.create();
+      boolean shouldThrowErrors = {{localVariablePrefix}}apiClient.getShouldThrowErrors();
+      {{localVariablePrefix}}apiClient.invokeAsync(request, null, new AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>>() {
+        @Override
+        public void onCompleted(ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response) {
+          notifySuccess(future, callback, response);
+        }
+
+        @Override
+        public void onFailed(Throwable exception) {
+          if (exception instanceof ApiException) {
+            @SuppressWarnings("unchecked")
+            ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response = (ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>)(ApiResponse<?>)exception;
+            notifySuccess(future, callback, response);
+          }
+          if (shouldThrowErrors) {
+            notifyFailure(future, callback, exception);
+          }
+          else {
+            @SuppressWarnings("unchecked")
+            ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response = (ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>)(ApiResponse<?>)(new ApiException(exception));
+            notifySuccess(future, callback, response);
+          }
+        }
+      });
+      return future;
+    }
+    catch (Throwable exception) {
+      return Futures.immediateFailedFuture(exception);
+    }
   }
 
   {{/operation}}
+
+  private <T> void notifySuccess(SettableFuture<T> future, AsyncApiCallback<T> callback, T result) {
+    if (callback != null) {
+      try {
+        callback.onCompleted(result);
+        future.set(result);
+      }
+      catch (Throwable exception) {
+        future.setException(exception);
+      }
+    }
+    else {
+      future.set(result);
+    }
+  }
+
+  private <T> void notifyFailure(SettableFuture<T> future, AsyncApiCallback<T> callback, Throwable exception) {
+    if (callback != null) {
+      try {
+        callback.onFailed(exception);
+        future.setException(exception);
+      }
+      catch (Throwable callbackException) {
+        future.setException(callbackException);
+      }
+    }
+    else {
+      future.setException(exception);
+    }
+  }
 }
 {{/operations}}

--- a/resources/sdk/purecloudjava/templates/requestBuilder.mustache
+++ b/resources/sdk/purecloudjava/templates/requestBuilder.mustache
@@ -23,10 +23,7 @@ import java.util.regex.Pattern;
 
 {{#operation}}
 public class {{requestClassname}} {
-    private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)application\\/json(;.*)?");
-    private static final String[] AUTH_NAMES = new String[] { };
-
-	{{#allParams}}
+    {{#allParams}}
 	private {{{dataType}}} {{paramName}};
 	public {{{dataType}}} get{{paramTitle}}() {
 		return this.{{paramName}};
@@ -122,6 +119,12 @@ public class {{requestClassname}} {
 
 
 		public {{requestClassname}} build() {
+            {{#allParams}}{{#required}}
+            // verify the required parameter '{{paramName}}' is set
+            if (request.{{paramName}} == null) {
+                throw new IllegalStateException("Missing the required parameter '{{paramName}}' when building request for {{classname}}.");
+            }
+            {{/required}}{{/allParams}}
 			return request;
 		}
 	}


### PR DESCRIPTION
Cleaned up the implementation of `invoke` in `ApiClient` quite a bit and moved the onus of the exception handling into the API classes.