### PR TITLE
API-2464

### DIFF
--- a/resources/sdk/purecloudjava/templates/api.mustache
+++ b/resources/sdk/purecloudjava/templates/api.mustache
@@ -43,7 +43,8 @@ public class {{classname}} {
    * {{notes}}{{#allParams}}
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}{{#returnType}}
    * @return {{{returnType}}}{{/returnType}}
-   * @throws ApiException if fails to make API call
+   * @throws ApiException if the request fails on the server
+   * @throws IOException if the request fails to be processed
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException, ApiException {
     {{#returnType}}return {{/returnType}} {{operationId}}(create{{requestClassname}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}));
@@ -54,9 +55,9 @@ public class {{classname}} {
    * {{notes}}{{#allParams}}
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}{{#returnType}}
    * @return {{{returnType}}}{{/returnType}}
-   * @throws ApiException if fails to make API call
+   * @throws IOException if the request fails to be processed
    */
-  public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException, ApiException {
+  public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws IOException {
     return {{operationId}}(create{{requestClassname}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).withHttpInfo());
   }
 
@@ -70,8 +71,10 @@ public class {{classname}} {
   /**
    * {{summary}}
    * {{notes}}
-   * @request The request object
-   * @throws ApiException if fails to make API call
+   * @param request The request object{{#returnType}}
+   * @return {{{returnType}}}{{/returnType}}
+   * @throws ApiException if the request fails on the server
+   * @throws IOException if the request fails to be processed
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{requestClassname}} request) throws IOException, ApiException {
     try {
@@ -87,10 +90,11 @@ public class {{classname}} {
   /**
    * {{summary}}
    * {{notes}}
-   * @request The request object
-   * @throws ApiException if fails to make API call
+   * @param request The request object
+   * @return the response
+   * @throws IOException if the request fails to be processed
    */
-  public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request) throws IOException, ApiException {
+  public {{#returnType}}ApiResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}ApiResponse<Void>{{/returnType}} {{operationId}}(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request) throws IOException {
     try {
       return {{localVariablePrefix}}apiClient.invoke(request, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}});
     }

--- a/resources/sdk/purecloudjava/templates/api_async.mustache
+++ b/resources/sdk/purecloudjava/templates/api_async.mustache
@@ -79,14 +79,15 @@ public class {{classname}}Async {
   /**
    * {{summary}}
    * {{notes}}
-   * @request The request object
-   * @throws ApiException if fails to make API call
+   * @param request the request object
+   * @param callback the action to perform when the request is completed
+   * @return the future indication when the request has completed
    */
   public Future<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> {{operationId}}Async(ApiRequest<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Void{{/bodyParam}}> request, AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> callback) {
     try {
       SettableFuture<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> future = SettableFuture.create();
       boolean shouldThrowErrors = {{localVariablePrefix}}apiClient.getShouldThrowErrors();
-      {{localVariablePrefix}}apiClient.invokeAsync(request, null, new AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>>() {
+      {{localVariablePrefix}}apiClient.invokeAsync(request, {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}}, new AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>>() {
         @Override
         public void onCompleted(ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response) {
           notifySuccess(future, callback, response);

--- a/resources/sdk/purecloudjava/templates/api_async.mustache
+++ b/resources/sdk/purecloudjava/templates/api_async.mustache
@@ -45,14 +45,15 @@ public class {{classname}}Async {
   /**
    * {{summary}}
    * {{notes}}
-   * @request The request object
-   * @throws ApiException if fails to make API call
+   * @param request the request object
+   * @param callback the action to perform when the request is completed
+   * @return the future indication when the request has completed
    */
   public Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}Async({{requestClassname}} request, AsyncApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> callback) {
     try {
       SettableFuture<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> future = SettableFuture.create();
       boolean shouldThrowErrors = {{localVariablePrefix}}apiClient.getShouldThrowErrors();
-      {{localVariablePrefix}}apiClient.invokeAsync(request.withHttpInfo(), null, new AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>>() {
+      {{localVariablePrefix}}apiClient.invokeAsync(request.withHttpInfo(), {{#returnType}}new TypeReference<{{{returnType}}}>() {}{{/returnType}}{{^returnType}}null{{/returnType}}, new AsyncApiCallback<ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>>() {
         @Override
         public void onCompleted(ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> response) {
           notifySuccess(future, callback, response.getBody());


### PR DESCRIPTION
Fixes the javadocs to better document the exceptions thrown by the API methods.  Also fixes some of the method exceptions to better represent what can be actually thrown.

Fixes bug in async API class where the required `TypeReference` is not passed to `ApiClient`.